### PR TITLE
Fix: Add CSP meta tag with 'unsafe-eval' to allow string evaluation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Noto+Sans:wght@400;700&display=swap"
       rel="stylesheet"
     />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' https://fonts.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com; object-src 'none'; img-src 'self' data:;">
   </head>
   <body class="bg-arcade-bg font-sans text-arcade-text">
     <div id="root"></div>


### PR DESCRIPTION
This change introduces a Content Security Policy (CSP) via a meta tag in `src/index.html`. The policy includes 'unsafe-eval' in the `script-src` directive.

This is an attempt to resolve an issue where your site's CSP was blocking the use of 'eval' or eval-like functions in JavaScript, which could be originating from third-party libraries or build tool outputs.

The full CSP added is:
default-src 'self'; script-src 'self' 'unsafe-eval' https://fonts.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com; object-src 'none'; img-src 'self' data:;

Note: The use of 'unsafe-eval' can have security implications as it weakens protections against inline script injection. This change should be monitored, and if possible, the underlying cause of 'eval' usage should be investigated and refactored to remove the need for 'unsafe-eval'.