### PR TITLE
Add placeholder test script to CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run tests
+        run: npm test
+
       - name: Build application
         run: npm run build
 

--- a/.github/workflows/fetch-news.yml
+++ b/.github/workflows/fetch-news.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run tests
+        run: npm test
+
       - name: Fetch new blog posts
         env:
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "echo \"No tests defined\" && exit 0"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",


### PR DESCRIPTION
## Summary
- add a no-op `npm test` script to `package.json`
- run the test script in CI workflows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68425e23b3d8832ea3ab3d94701a740d