### PR TITLE
Add sitemap generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ GEMINI_API_KEY_SERVER=your_server_side_key
 NEWS_API_KEY=your_newsapi_key
 ```
 
+### Sitemap Generation
+
+Run `npm run sitemap` to create `public/sitemap.xml` and update `public/robots.txt` with the sitemap URL. Submit this file to search engines to improve indexing.
+

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "sitemap": "node scripts/generate-sitemap.js",
     "preview": "vite preview",
     "test": "echo \"No tests defined\" && exit 0"
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.aisolutionsconsulting.net/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.aisolutionsconsulting.net/</loc>
+  </url>
+  <url>
+    <loc>https://www.aisolutionsconsulting.net/about</loc>
+  </url>
+  <url>
+    <loc>https://www.aisolutionsconsulting.net/blog</loc>
+  </url>
+  <url>
+    <loc>https://www.aisolutionsconsulting.net/contact</loc>
+  </url>
+  <url>
+    <loc>https://www.aisolutionsconsulting.net/prompt-library</loc>
+  </url>
+  <url>
+    <loc>https://www.aisolutionsconsulting.net/tools</loc>
+  </url>
+</urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.aisolutionsconsulting.net/</loc>
-  </url>
-  <url>
     <loc>https://www.aisolutionsconsulting.net/about</loc>
   </url>
   <url>
@@ -11,6 +8,9 @@
   </url>
   <url>
     <loc>https://www.aisolutionsconsulting.net/contact</loc>
+  </url>
+  <url>
+    <loc>https://www.aisolutionsconsulting.net/</loc>
   </url>
   <url>
     <loc>https://www.aisolutionsconsulting.net/prompt-library</loc>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+
+const BASE_URL = 'https://www.aisolutionsconsulting.net';
+const pages = [
+  '/',
+  '/about',
+  '/blog',
+  '/contact',
+  '/prompt-library',
+  '/tools',
+];
+
+const urls = pages.map(p => {
+  return `  <url>\n    <loc>${BASE_URL}${p}</loc>\n  </url>`;
+}).join('\n');
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+`${urls}\n` +
+`</urlset>\n`;
+
+const outputDir = path.join(__dirname, '../public');
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}
+fs.writeFileSync(path.join(outputDir, 'sitemap.xml'), xml.trim() + '\n');
+console.log('Sitemap generated at', path.join(outputDir, 'sitemap.xml'));

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -2,27 +2,48 @@ const fs = require('fs');
 const path = require('path');
 
 const BASE_URL = 'https://www.aisolutionsconsulting.net';
-const pages = [
-  '/',
-  '/about',
-  '/blog',
-  '/contact',
-  '/prompt-library',
-  '/tools',
-];
 
-const urls = pages.map(p => {
-  return `  <url>\n    <loc>${BASE_URL}${p}</loc>\n  </url>`;
-}).join('\n');
-
-const xml = `<?xml version="1.0" encoding="UTF-8"?>\n` +
-`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
-`${urls}\n` +
-`</urlset>\n`;
-
-const outputDir = path.join(__dirname, '../public');
-if (!fs.existsSync(outputDir)) {
-  fs.mkdirSync(outputDir, { recursive: true });
+function toKebab(str) {
+  return str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/\s+/g, '-')
+    .toLowerCase();
 }
-fs.writeFileSync(path.join(outputDir, 'sitemap.xml'), xml.trim() + '\n');
-console.log('Sitemap generated at', path.join(outputDir, 'sitemap.xml'));
+
+function getPages() {
+  const pagesDir = path.join(__dirname, '../src/pages');
+  return fs.readdirSync(pagesDir)
+    .filter(f => f.endsWith('.tsx'))
+    .map(f => {
+      const name = f.replace(/\.tsx$/, '');
+      if (name === 'Home') return '/';
+      return '/' + toKebab(name);
+    });
+}
+
+const pages = getPages();
+
+const urls = pages.map(p => `  <url>\n    <loc>${BASE_URL}${p}</loc>\n  </url>`).join('\n');
+
+const xml =
+  `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+  `${urls}\n` +
+  `</urlset>\n`;
+
+const publicDir = path.join(__dirname, '../public');
+if (!fs.existsSync(publicDir)) {
+  fs.mkdirSync(publicDir, { recursive: true });
+}
+fs.writeFileSync(path.join(publicDir, 'sitemap.xml'), xml.trim() + '\n');
+
+const robotsPath = path.join(publicDir, 'robots.txt');
+let robots = fs.existsSync(robotsPath) ? fs.readFileSync(robotsPath, 'utf8') : 'User-agent: *\nAllow: /\n';
+if (!/Sitemap:/i.test(robots)) {
+  robots += (robots.endsWith('\n') ? '' : '\n') + `Sitemap: ${BASE_URL}/sitemap.xml\n`;
+} else {
+  robots = robots.replace(/Sitemap:.*/i, `Sitemap: ${BASE_URL}/sitemap.xml`);
+}
+fs.writeFileSync(robotsPath, robots.trim() + '\n');
+
+console.log('Generated sitemap.xml and updated robots.txt');


### PR DESCRIPTION
## Summary
- create sitemap generator script
- add robots.txt referencing sitemap
- generate sitemap.xml
- document new `npm run sitemap` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846055d0520832eb5fc55e66668b50a