### PR TITLE
Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ Run `npm run sitemap` to create `public/sitemap.xml` and update `public/robots.t
 
 The script scans `src/pages` for `.tsx` files and automatically updates the list of URLs. Run it again whenever you add or rename a page to keep the sitemap current.
 
+### Installation
+
+Before running the build or development server, install dependencies with:
+
+```bash
+npm install
+```
+
+Then you can start a dev server using `npm run dev` or create a production build with `npm run build` (also used by Netlify, see [`netlify.toml`](netlify.toml)).
+


### PR DESCRIPTION
## Summary
- add installation instructions about running `npm install`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685218d1b174832ebf0aaa9d432ffacf