### PR TITLE
Fix build by restoring content config

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -3,7 +3,13 @@ import { defineCollection, z } from 'astro:content';
 const blog = defineCollection({
   schema: z.object({
     title: z.string(),
-
+    description: z.string().optional(),
+    pubDate: z.string().or(z.date()),
+    author: z.string().optional(),
+    source: z.string().optional(),
+    sourceUrl: z.string().optional(),
+    tags: z.array(z.string()).optional()
+  })
 });
 
 export const collections = { blog };


### PR DESCRIPTION
## Summary
- fix the syntax in `src/content/config.ts`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68660bca20d8832e86bcb23c3ce55d8e