### PR TITLE
Refocus site on Automation SaaS

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,7 +15,7 @@ export default function App(): React.ReactNode {
       <Header />
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/platform" element={<Platform />} />
+        <Route path="/automation-saas" element={<Platform />} />
         <Route path="/consulting" element={<Consulting />} />
         <Route path="/case-studies" element={<CaseStudies />} />
         <Route path="/insights" element={<Insights />} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 const Header = (): React.ReactNode => {
   const navLinks = [
-    { name: 'Platform', href: '/platform' },
+    { name: 'Automation SaaS', href: '/automation-saas' },
     { name: 'Consulting', href: '/consulting' },
     { name: 'Case Studies', href: '/case-studies' },
     { name: 'Insights', href: '/insights' },

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -13,6 +13,15 @@ export const SparklesIcon = ({ className }: IconProps): React.ReactNode => (
     </svg>
 );
 
+export const PenToolIcon = ({ className }: IconProps): React.ReactNode => (
+    <svg xmlns="http://www.w3.org/2000/svg" className={className} width="24" height="24" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 19l7-7 3 3-7 7-3-3z" />
+        <path d="M18 13l-5-5" />
+        <path d="M11 8l-5-5L2 7l5 5" />
+        <circle cx="11" cy="8" r="2" />
+    </svg>
+);
+
 export const ShieldCheckIcon = ({ className }: IconProps): React.ReactNode => (
     <svg xmlns="http://www.w3.org/2000/svg" className={className} width="24" height="24" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round">
         <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,22 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Enterprise Cloud Transformation Services | AI Solutions Consulting</title>
-    <meta name="description" content="Unlock ROI with our AI-powered enterprise cloud transformation services. We deliver secure cloud migration, zero-trust security, and help you secure grant funding to offset costs. Partner with AI Solutions Consulting.">
+    <title>Automation SaaS Workflows | AI Solutions Consulting</title>
+    <meta name="description" content="Scalable n8n-powered SaaS modules for email triage, support intelligence &amp; SaaS-to-SaaS syncing.">
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              accentPen: '#18E2BF',
+              accentShield: '#C77DFF',
+              accentChart: '#FF5CF2',
+            },
+          },
+        },
+      };
+    </script>
     <style>
       @keyframes spin {
         from {

--- a/pages/Consulting.tsx
+++ b/pages/Consulting.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SparklesIcon, ShieldCheckIcon, ChartBarIcon } from '../components/Icons';
+import { PenToolIcon, ShieldCheckIcon, ChartBarIcon } from '../components/Icons';
 
 const WaveDivider = (): React.ReactNode => {
   return (
@@ -34,58 +34,30 @@ export default function Consulting(): React.ReactNode {
       </header>
       <WaveDivider />
       <main>
-        <section className="mx-auto max-w-6xl grid gap-8 md:grid-cols-2 py-16 px-6">
-          {/* SaaS AI Platform Setup */}
-          <div className="flex flex-col items-center text-center bg-slate-800/40 rounded-xl p-6">
-            <div className="flex items-center justify-center h-16 w-16 rounded-full bg-teal-400/10 mb-2">
-              <SparklesIcon className="w-8 h-8 text-teal-400" />
+        <section className="mx-auto max-w-6xl grid gap-8 md:grid-cols-3 py-16 px-6">
+          <div className="bg-gray-900 rounded-3xl p-8 shadow-lg hover:-translate-y-1 transition">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-accentPen/10">
+              <PenToolIcon className="w-6 h-6 text-accentPen" />
             </div>
-            <h3 className="mt-2 font-semibold text-slate-100 text-lg">SaaS AI Platform Setup</h3>
-            <p className="mt-2 text-sm text-slate-400">Deploy pre-built AI solutions in your cloud environment for instant productivity gains.</p>
-            <ul className="mt-4 text-sm text-slate-300 text-left">
-              <li><strong>Timeline:</strong> 30–60 days</li>
-              <li><strong>Starting at:</strong> $7,500</li>
-              <li><strong>Platforms:</strong> Azure AI, Google Cloud AI, AWS SageMaker</li>
-            </ul>
+            <h3 className="text-lg font-semibold text-white">Email Lead Triage</h3>
+            <p className="mt-2 text-sm text-slate-400">AI scores & routes hot leads</p>
+            <a href="/automation-saas/#triage" className="mt-4 inline-block font-semibold text-accentPen hover:underline">See details →</a>
           </div>
-          {/* Custom SaaS Integration */}
-          <div className="flex flex-col items-center text-center bg-slate-800/40 rounded-xl p-6">
-            <div className="flex items-center justify-center h-16 w-16 rounded-full bg-teal-400/10 mb-2">
-              <ShieldCheckIcon className="w-8 h-8 text-teal-400" />
+          <div className="bg-gray-900 rounded-3xl p-8 shadow-lg hover:-translate-y-1 transition">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-accentShield/10">
+              <ShieldCheckIcon className="w-6 h-6 text-accentShield" />
             </div>
-            <h3 className="mt-2 font-semibold text-slate-100 text-lg">Custom SaaS Integration</h3>
-            <p className="mt-2 text-sm text-slate-400">Connect AI tools to your existing SaaS stack (Salesforce, HubSpot, etc.) for seamless workflows.</p>
-            <ul className="mt-4 text-sm text-slate-300 text-left">
-              <li><strong>Timeline:</strong> 45–90 days</li>
-              <li><strong>Starting at:</strong> $10,000</li>
-              <li><strong>Platforms:</strong> Salesforce, HubSpot, Zapier, Slack, Microsoft 365</li>
-            </ul>
+            <h3 className="text-lg font-semibold text-white">Support Intelligence</h3>
+            <p className="mt-2 text-sm text-slate-400">Prioritise VIP tickets</p>
+            <a href="/automation-saas/#support" className="mt-4 inline-block font-semibold text-accentShield hover:underline">See details →</a>
           </div>
-          {/* SaaS AI Optimization */}
-          <div className="flex flex-col items-center text-center bg-slate-800/40 rounded-xl p-6">
-            <div className="flex items-center justify-center h-16 w-16 rounded-full bg-teal-400/10 mb-2">
-              <ChartBarIcon className="w-8 h-8 text-teal-400" />
+          <div className="bg-gray-900 rounded-3xl p-8 shadow-lg hover:-translate-y-1 transition">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-accentChart/10">
+              <ChartBarIcon className="w-6 h-6 text-accentChart" />
             </div>
-            <h3 className="mt-2 font-semibold text-slate-100 text-lg">SaaS AI Optimization</h3>
-            <p className="mt-2 text-sm text-slate-400">Maximize ROI from your current AI software investments with expert tuning and analytics.</p>
-            <ul className="mt-4 text-sm text-slate-300 text-left">
-              <li><strong>Timeline:</strong> 30–60 days</li>
-              <li><strong>Starting at:</strong> $5,000</li>
-              <li><strong>Platforms:</strong> Azure AI, Google Cloud AI, DataRobot, OpenAI</li>
-            </ul>
-          </div>
-          {/* Cloud Migration & AI Enablement */}
-          <div className="flex flex-col items-center text-center bg-slate-800/40 rounded-xl p-6">
-            <div className="flex items-center justify-center h-16 w-16 rounded-full bg-teal-400/10 mb-2">
-              <SparklesIcon className="w-8 h-8 text-teal-400" />
-            </div>
-            <h3 className="mt-2 font-semibold text-slate-100 text-lg">Cloud Migration & AI Enablement</h3>
-            <p className="mt-2 text-sm text-slate-400">Move legacy systems to cloud-first AI solutions for future-ready operations.</p>
-            <ul className="mt-4 text-sm text-slate-300 text-left">
-              <li><strong>Timeline:</strong> 60–90 days</li>
-              <li><strong>Starting at:</strong> $15,000</li>
-              <li><strong>Platforms:</strong> AWS, Azure, Google Cloud, Microsoft 365</li>
-            </ul>
+            <h3 className="text-lg font-semibold text-white">SaaS Sync Hub</h3>
+            <p className="mt-2 text-sm text-slate-400">Salesforce ↔ HubSpot ↔ Slack</p>
+            <a href="/automation-saas/#sync" className="mt-4 inline-block font-semibold text-accentChart hover:underline">See details →</a>
           </div>
         </section>
         <footer className="py-16">

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -43,16 +43,15 @@ export default function Home(): React.ReactNode {
         <header className="grid md:grid-cols-2 items-center gap-8 px-6 max-w-6xl mx-auto py-12 md:py-20">
           <div className="text-left">
             <h1 className="text-4xl lg:text-5xl font-extrabold tracking-tight text-white">
-              AI Solutions, Made Practical.
+              Automation SaaS that runs your busywork 24 / 7.
             </h1>
             <p className="mt-6 text-lg text-slate-300">
-              Cloud-native AI solutions that scale with your business – no infrastructure headaches, no lengthy implementations
+              Plug-and-play workflows for email triage, lead nurturing &amp; SaaS sync—deployed in one day.
             </p>
             <div className="mt-4 flex flex-wrap gap-3 text-base text-teal-300 font-semibold">
-              <span>✓ 30-day deployment</span>
-              <span>✓ Cloud-hosted</span>
-              <span>✓ Pay-as-you-scale</span>
-              <span>✓ White-glove migration</span>
+              <span>✓ Scales with your inbox</span>
+              <span>✓ N8N powered, fully editable</span>
+              <span>✓ ROI-backed guarantee</span>
             </div>
           </div>
 
@@ -95,8 +94,8 @@ export default function Home(): React.ReactNode {
               </svg>
             </button>
             <div className="mt-6">
-              <a href="/contact" className="inline-block rounded-md bg-teal-400 px-8 py-4 font-semibold text-slate-900 shadow hover:bg-teal-300 transition">
-                Get Your SaaS AI Assessment
+              <a href="/automation-saas" className="inline-block rounded-md bg-teal-400 px-8 py-4 font-semibold text-slate-900 shadow hover:bg-teal-300 transition">
+                Explore Automation SaaS
               </a>
             </div>
           </div>
@@ -139,7 +138,7 @@ export default function Home(): React.ReactNode {
                   Launch enterprise-grade capabilities without the enterprise overhead. Our SaaS platform plugs into your
                   existing tools and gets you up and running in days, not months.
                 </p>
-                <a href="/platform" className="mt-4 inline-block font-semibold text-teal-400 hover:underline">
+                <a href="/automation-saas" className="mt-4 inline-block font-semibold text-teal-400 hover:underline">
                   How the Platform Works →
                 </a>
               </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  content: ['./index.html', './pages/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        accentPen: '#18E2BF',
+        accentShield: '#C77DFF',
+        accentChart: '#FF5CF2',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- update homepage hero for Automation SaaS focus
- rename Platform navigation to **Automation SaaS**
- convert consulting page to product cards
- adjust SEO defaults and Tailwind colour tokens
- add missing PenToolIcon

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882ce6e12bc832e86f0e7b469def355